### PR TITLE
Fix hero layout for Surface Pro

### DIFF
--- a/CSS/responsive.css
+++ b/CSS/responsive.css
@@ -124,7 +124,7 @@
       }
       @media (max-width: 992px) {
         .hero-wrap {
-          grid-template-columns: 120px 1fr;
+          grid-template-columns: minmax(120px, 160px) 1fr;
           gap: 1.25rem;
         }
       }


### PR DESCRIPTION
## Summary
- fix hero layout at tablet widths so avatar no longer overlaps name

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e87cafb883228e2c80ac2db4322e