### PR TITLE
fix: lighten navbar in light mode

### DIFF
--- a/CSS/header.css
+++ b/CSS/header.css
@@ -7,6 +7,11 @@
         backdrop-filter: blur(var(--blur));
         border-bottom: 1px solid var(--border);
       }
+      @media (prefers-color-scheme: light) {
+        header.site-header {
+          background: rgba(255, 255, 255, 0.7);
+        }
+      }
       .nav {
         display: flex;
         align-items: center;


### PR DESCRIPTION
## Summary
- lighten header background for light mode to keep navigation readable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ea3cb0cc8322a3c2823d044d0a61